### PR TITLE
feat: add AWS support to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,16 @@ on:
       gcp_project_id:
         required: false
         type: string
+      aws_role_arn:
+        required: false
+        type: string
+        default: ""
+        description: "AWS IAM role ARN for OIDC authentication (AWS only)"
+      aws_account_id:
+        required: false
+        type: string
+        default: ""
+        description: "AWS Account ID for ECR registry (AWS only)"
 
 jobs:
   build:
@@ -40,6 +50,12 @@ jobs:
           workload_identity_provider: ${{ inputs.workload_identity_provider }}
           service_account: ${{ inputs.service_account }}
         if: ${{ inputs.registry == 'gcp' }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.aws_role_arn }}
+          aws-region: ${{ inputs.region }}
+        if: ${{ inputs.registry == 'aws' }}
       - name: Helm Chart Build
         uses: martoc/action-helm-build@v0
         with:
@@ -47,5 +63,6 @@ jobs:
           region: ${{ inputs.region }}
           repository_name: ${{ inputs.repository_name }}
           gcp_project_id: ${{ inputs.gcp_project_id }}
+          aws_account_id: ${{ inputs.aws_account_id }}
       - name: Release on GitHub
         uses: martoc/action-release@v0

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -48,6 +48,8 @@ Builds and pushes Helm charts to a container registry.
 | `workload_identity_provider` | string | No | - | GCP Workload Identity Provider (GCP only) |
 | `service_account` | string | No | - | GCP Service Account (GCP only) |
 | `gcp_project_id` | string | No | - | GCP project ID (GCP only) |
+| `aws_role_arn` | string | No | - | AWS IAM role ARN for OIDC authentication (AWS only) |
+| `aws_account_id` | string | No | - | AWS Account ID for ECR registry (AWS only) |
 
 **Example (GCP):**
 
@@ -65,6 +67,23 @@ jobs:
       gcp_project_id: my-project
       workload_identity_provider: ${{ vars.WIF_PROVIDER }}
       service_account: ${{ vars.SERVICE_ACCOUNT }}
+```
+
+**Example (AWS):**
+
+```yaml
+jobs:
+  build:
+    permissions:
+      contents: write
+      id-token: write
+    uses: martoc/workflow-helm-chart/.github/workflows/build.yml@v0
+    with:
+      registry: aws
+      region: eu-west-1
+      repository_name: helm-charts
+      aws_role_arn: ${{ vars.AWS_ROLE_ARN }}
+      aws_account_id: ${{ vars.AWS_ACCOUNT_ID }}
 ```
 
 ### deploy.yml


### PR DESCRIPTION
## Summary

- Add aws_role_arn and aws_account_id inputs to build workflow for AWS OIDC authentication and ECR registry access
- Add Configure AWS Credentials step using aws-actions/configure-aws-credentials@v4, conditional on registry == aws
- Pass aws_account_id to martoc/action-helm-build@v0 action
- Update USAGE.md with new inputs documentation and AWS build example

## Test plan

- [ ] Test build workflow with registry: aws to verify AWS credentials are configured
- [ ] Test build workflow with registry: gcp to verify no regression
- [ ] Verify Helm chart is pushed to ECR successfully