### PR TITLE
fix: upgrade actions to versions supporting Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 10
           fetch-tags: true
@@ -51,7 +51,7 @@ jobs:
           service_account: ${{ inputs.service_account }}
         if: ${{ inputs.registry == 'gcp' }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ inputs.aws_role_arn }}
           aws-region: ${{ inputs.region }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
       name: ${{ inputs.registry }}/${{ inputs.environment }}/${{ inputs.region }}/${{ inputs.cluster_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
         if: inputs.ref != 'main'
@@ -79,7 +79,7 @@ jobs:
           execute: load
         if: inputs.ref == 'main'
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: inputs.ref == 'main'
       - name: Helm Chart Deploy
         uses: martoc/action-helm-deploy@v0

--- a/docs/CODESTYLE.md
+++ b/docs/CODESTYLE.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Descriptive Step Name
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 ```
 
 ### Conditional Steps


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → v6 in `.github/workflows/build.yml`, `.github/workflows/deploy.yml`, and `docs/CODESTYLE.md`
- Bump `aws-actions/configure-aws-credentials` v4 → v6 in `.github/workflows/build.yml`

## Why

GitHub Actions has deprecated Node.js 20 (see [deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). From 2 June 2026, affected actions will be forced onto Node.js 24; Node.js 20 is removed from the runner on 16 September 2026. The bumped versions run on Node.js 24 by default.

## Test plan

- [ ] CI checks pass
- [ ] Reusable workflow callers continue to build and deploy charts successfully
